### PR TITLE
Fix incorrect payload access when retrieving aliases

### DIFF
--- a/yente/search/indexer.py
+++ b/yente/search/indexer.py
@@ -157,7 +157,7 @@ async def index_entities(es: AsyncOpenSearch, dataset: Dataset, force: bool) -> 
     log.info("Index is now aliased to: %s" % settings.ENTITY_INDEX, index=next_index)
 
     res = await es.indices.get_alias(name=settings.ENTITY_INDEX)
-    for aliased_index in res.body.keys():
+    for aliased_index in res.keys():
         if aliased_index == next_index:
             continue
         if aliased_index.startswith(dataset_prefix):

--- a/yente/search/queries.py
+++ b/yente/search/queries.py
@@ -200,11 +200,6 @@ def iter_sorts(sorts: List[str]) -> Generator[Tuple[str, str], None, None]:
         yield sort, order
 
 
-def parse_sorts(sorts: List[str], default: Optional[str] = "_score") -> List[Any]:
+def parse_sorts(sorts: List[str], default: Optional[List[str]] = ["_score:desc"]) -> str:
     """Accept sorts of the form: <field>:<order>, e.g. first_seen:desc."""
-    objs: List[Any] = []
-    for sort, order in iter_sorts(sorts):
-        objs.append({sort: {"order": order, "missing": "_last"}})
-    if default is not None:
-        objs.append(default)
-    return objs
+    return ",".join(sorts)

--- a/yente/search/search.py
+++ b/yente/search/search.py
@@ -85,7 +85,7 @@ async def search_entities(
     limit: int = 5,
     offset: int = 0,
     aggregations: Optional[Dict[str, Any]] = None,
-    sort: List[Any] = [],
+    sort: Optional[str] = None,
 ) -> Any:
     es = await get_es()
     es_ = es

--- a/yente/search/status.py
+++ b/yente/search/status.py
@@ -9,7 +9,7 @@ log = get_logger(__name__)
 async def sync_dataset_versions(catalog: Catalog) -> None:
     es = await get_es()
     res = await es.indices.get_alias(name=settings.ENTITY_INDEX)
-    for aliased_index in res.body.keys():
+    for aliased_index in res.keys():
         aliased_end: str = aliased_index[len(settings.ENTITY_INDEX) + 1 :]
         dataset_name, index_version = aliased_end.split("-", 1)
         version = index_version[len(settings.INDEX_VERSION) :]


### PR DESCRIPTION
There were two instances in the code where the current aliases are fetched from the OpenSearch cluster. The method call will return a dictionary. However, the code was assuming a Response and thus called `#body` on it. Since it's a dictionary, we can iterate the values directly.

The fallout from this was that a reindex would finish (new index created, default alias pointed at it) but the old indices wouldn't be deleted. This meant wasted disk space but also, more annoyingly, the same alias pointed at multiple indices. As it turns out, this is an option and basically means that you can query against a single alias which will then forward it to *multiple* indices. For us this meant we were getting lots of duplicate results.

A second occurrence of the same bug can be found in the `/catalog` endpoint. In this case, it only meant that it didn't work but no repercussions for the querying.

As a side fix to get the test suite green, this PR also changes how the sort parameters are passed to the OpenSearch client. This has an impact on `/search` only which we aren't using.