### PR TITLE
Remove CI workflows that aren't relevant to us

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,10 +2,6 @@ name: build
 
 on: [push]
 
-permissions:
-  packages: write
-  id-token: write
-
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -37,7 +33,7 @@ jobs:
         env:
           DEBIAN_FRONTEND: noninteractive
         run: |
-          pip install -U pip setuptools wheel
+          pip install -U pip
           sudo apt-get install -y -qq libicu-dev
           pip install -q -e ".[dev]"
           pip freeze
@@ -47,52 +43,3 @@ jobs:
       - name: Run pytest
         run: |
           pytest -v tests/unit
-      - name: Build a distribution
-        run: |
-          python setup.py sdist bdist_wheel
-      - name: Publish a Python distribution to PyPI
-        if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          skip-existing: true
-
-  build:
-    runs-on: ubuntu-latest
-    needs: [test]
-    steps:
-      - uses: actions/checkout@v4
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-      - name: Docker meta
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ghcr.io/opensanctions/yente
-          tags: |
-            type=ref,event=branch
-            type=semver,pattern={{version}}
-            type=sha
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-        with:
-          install: true
-      - name: Debug information
-        run: |
-          docker --version
-          echo "${GITHUB_REF}"
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build and push release
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max


### PR DESCRIPTION
The CI workflow is trying to a push new container to the GitHub container registry. We don't need / want that, so just removing most of the CI workflows here except for type checking and unit testing.