### PR TITLE
Add configurable keep-alive timeout setting to uvicorn

### DIFF
--- a/yente/cli.py
+++ b/yente/cli.py
@@ -32,6 +32,7 @@ def serve() -> None:
             # debug=settings.DEBUG,
             log_level=settings.LOG_LEVEL,
             server_header=False,
+            timeout_keep_alive=settings.TIMEOUT_KEEP_ALIVE,
         ),
     )
     configure_logging()

--- a/yente/settings.py
+++ b/yente/settings.py
@@ -108,6 +108,7 @@ RESOURCES_PATH = Path(__file__).parent.joinpath("resources")
 
 BASE_SCHEMA = "Thing"
 PORT = int(env_str("YENTE_PORT", env_str("PORT", "8000")))
+TIMEOUT_KEEP_ALIVE = int(env_str("YENTE_TIMEOUT_KEEP_ALIVE", "5"))
 UPDATE_TOKEN = env_str("YENTE_UPDATE_TOKEN", "unsafe-default")
 CACHE_HEADERS = {
     "Cache-Control": "public; max-age=3600",


### PR DESCRIPTION
Following investigation into some `502` HTTP status code during benchmarks, we want to be able to configure the keep-alive timeout for Yente. 

One of the remediations recommended by https://repost.aws/knowledge-center/elb-alb-troubleshoot-502-errors is to make sure the duration of the keep-alive timeout of the target, which is currently 5 seconds by default, is longer than the idle timeout value from the load balancer, which is currently 60 seconds.